### PR TITLE
Alterado o método construtor antigo para __construct

### DIFF
--- a/fpdf.php
+++ b/fpdf.php
@@ -73,7 +73,7 @@ var $PDFVersion;         // PDF version number
 *                               Public methods                                 *
 *                                                                              *
 *******************************************************************************/
-function FPDF($orientation='P', $unit='mm', $size='A4')
+function __construct($orientation='P', $unit='mm', $size='A4')
 {
 	// Some checks
 	$this->_dochecks();


### PR DESCRIPTION
Usando a versão 7 do PHP dá o seguinte erro (deprecated):

> Methods with the same name as their class will not be constructors in a future version of PHP; FPDF has a deprecated constructor

Alterei para __construct().