### PR TITLE
compatibilidade php >= 7.2

### DIFF
--- a/fpdi.php
+++ b/fpdi.php
@@ -559,10 +559,10 @@ class FPDISigep extends FPDF_TPLSigep
 
                 reset ($value[1]);
 
-                while (list($k, $v) = each($value[1])) {
-                    $this->_straightOut($k . ' ');
+                foreach($value[1] as $k=>$v) {
+					$this->_straightOut($k . ' ');
                     $this->_writeValue($v);
-                }
+				}
 
                 $this->_straightOut('>>');
                 break;


### PR DESCRIPTION
Em PHP >= 7.2 esta retornando 'each' como função descontinuada